### PR TITLE
修复 pnpm 构建脚本审批导致的启动失败

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -17,7 +17,7 @@ dsh-lark-channel start
 
 A QR code appears in the terminal. Scan it in Feishu to create the app, then DM the bot or @-mention it in a group.
 
-Before the first dependency install, the command writes the profile's pnpm build policy. It explicitly skips protobufjs's notice-only postinstall, so no manual `pnpm approve-builds` step is needed.
+Before the first dependency install, the command writes the profile's pnpm build policy: an unapproved dependency build script is warned about and skipped rather than failing the install, and protobufjs's notice-only postinstall is recorded as skipped by name. No manual `pnpm approve-builds` step is needed.
 
 Prefer to install nothing? Run it through npx instead — every later command then carries the same prefix:
 

--- a/README.en.md
+++ b/README.en.md
@@ -17,6 +17,8 @@ dsh-lark-channel start
 
 A QR code appears in the terminal. Scan it in Feishu to create the app, then DM the bot or @-mention it in a group.
 
+Before the first dependency install, the command writes the profile's pnpm build policy. It explicitly skips protobufjs's notice-only postinstall, so no manual `pnpm approve-builds` step is needed.
+
 Prefer to install nothing? Run it through npx instead — every later command then carries the same prefix:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ dsh-lark-channel start
 
 终端会显示二维码。用飞书扫码完成应用创建，然后私聊机器人，或在群里 @ 它即可开始。
 
+启动命令会在首次安装依赖前写好 profile 的 pnpm 构建策略；`protobufjs` 不影响运行的提示型 postinstall 会被明确跳过，不需要再手工执行 `pnpm approve-builds`。
+
 不想装到全局也可以直接跑，只是之后每条命令都要带 `npx`：
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ dsh-lark-channel start
 
 终端会显示二维码。用飞书扫码完成应用创建，然后私聊机器人，或在群里 @ 它即可开始。
 
-启动命令会在首次安装依赖前写好 profile 的 pnpm 构建策略；`protobufjs` 不影响运行的提示型 postinstall 会被明确跳过，不需要再手工执行 `pnpm approve-builds`。
+启动命令会在首次安装依赖前写好 profile 的 pnpm 构建策略：未经批准的依赖构建脚本一律警告并跳过，而不是让安装失败；`protobufjs` 那个只打印提示的 postinstall 还会被按名字记为跳过。因此不需要手工执行 `pnpm approve-builds`。
 
 不想装到全局也可以直接跑，只是之后每条命令都要带 `npx`：
 

--- a/cordis.patch.yml
+++ b/cordis.patch.yml
@@ -1,8 +1,8 @@
 # Bundle patch applied over the selected DSH profile when this package is listed
 # in `dsh.profile.bundles`. The row id is deployment-local; the package name
 # must match package.json.
-# Package installation policy (including pnpm allowBuilds) is prepared by the
-# provisioning CLI before this runtime patch is loaded.
+# Package installation policy (the profile's pnpm build-script settings) is
+# prepared by the provisioning CLI before this runtime patch is loaded.
 
 - insert:
     - id: lark-channel

--- a/cordis.patch.yml
+++ b/cordis.patch.yml
@@ -1,6 +1,8 @@
 # Bundle patch applied over the selected DSH profile when this package is listed
 # in `dsh.profile.bundles`. The row id is deployment-local; the package name
 # must match package.json.
+# Package installation policy (including pnpm allowBuilds) is prepared by the
+# provisioning CLI before this runtime patch is loaded.
 
 - insert:
     - id: lark-channel

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,7 +20,10 @@ import type { SessionScope } from './session.ts'
  */
 const DEFAULT_DENY_TOOLS = [] as const
 
-/** Plugin configuration supplied by the profile composition. */
+/**
+ * Runtime plugin configuration supplied by the profile composition. Package
+ * installation policy is owned by the provisioning CLI, not this schema.
+ */
 export interface Config {
   /**
    * Names this row when a deployment composes more than one, so two bots keep

--- a/src/provision.ts
+++ b/src/provision.ts
@@ -49,16 +49,34 @@ export const ONBOARDING_WATCH_MS = 10 * 60 * 1000
 /** Log size past which `start` truncates it, since no supervisor rotates it. */
 export const LOG_TRUNCATE_BYTES = 10 * 1024 * 1024
 
-/** pnpm policy a standalone profile needs before its first dependency install. */
+/**
+ * pnpm policy a standalone profile needs before its first dependency install.
+ *
+ * The first four lines mirror the profile template DSH itself writes (see
+ * `initProfile` in `@deepseek-ai/dsh-app-boot`); keep them in step when the
+ * host changes its own. Because this file is written first, DSH's writer —
+ * which only fills in an absent file — never runs on these profiles.
+ */
 const PROFILE_PNPM_WORKSPACE = `packages:
   - .
 
 nodeLinker: hoisted
 autoInstallPeers: false
 
+strictDepBuilds: false
+
 allowBuilds:
   protobufjs: false
 `
+
+/** The value pnpm parks under `allowBuilds` for a script nobody has judged yet. */
+const PNPM_BUILD_PLACEHOLDER = 'set this to true or false'
+
+/** A top-level key line, which is also where any `allowBuilds` block ends. */
+const TOP_LEVEL_KEY = /^([A-Za-z_][\w-]*)\s*:(.*)$/
+
+/** One package's decision inside an `allowBuilds` block. */
+const ALLOW_BUILDS_ENTRY = /^(\s+protobufjs\s*:\s*)(.*)$/
 
 /** What the operator asked for, after argument parsing. */
 export type Command =
@@ -496,36 +514,159 @@ function requireDsh(): string {
 }
 
 /**
- * Make protobufjs's optional postinstall an explicit decision before pnpm runs.
+ * Refuse a profile name that would place the workspace file outside the home.
  *
- * DSH creates a profile and installs its first plugin in one command. With
- * pnpm 11, that first install writes a placeholder decision for protobufjs and
- * then exits with ERR_PNPM_IGNORED_BUILDS. Pre-seeding the workspace avoids the
- * failed first pass; repairing the exact placeholder also recovers profiles
- * left behind by an older CLI. An operator's explicit true/false choice wins.
+ * This function writes before any `dsh` process runs, so it is the first thing
+ * to touch disk for a named profile — ahead of the host's own check. The rule
+ * is the host's rule (`resolveProfileDir`), not a stricter one, so a name DSH
+ * accepts is never rejected here.
+ * @param name - the requested profile name.
+ * @returns the refusal to report, or undefined when the name is usable.
+ */
+function refuseProfileName(name: string): string | undefined {
+  const reserved = name === '' || name === '.' || name === '..' || name === 'node_modules'
+  return reserved || name.includes('/') || name.includes('\\')
+    ? `invalid profile name ${JSON.stringify(name)}`
+    : undefined
+}
+
+/** The key a top-level line declares, or undefined when the line declares none. */
+function topLevelKey(line: string): string | undefined {
+  return TOP_LEVEL_KEY.exec(line)?.[1]
+}
+
+/** A line's content with any trailing comment removed. */
+function withoutComment(text: string): string {
+  return text.replace(/#.*$/, '').trim()
+}
+
+/**
+ * The indentation a block already gives its entries, so an added one lines up.
+ * A mapping whose entries disagree on depth is not a document pnpm can read.
+ * @param block - the lines between a top-level key and the next one.
+ * @returns the existing indentation, or the two spaces a new block takes.
+ */
+function blockIndent(block: readonly string[]): string {
+  for (const line of block) {
+    const indent = /^(\s+)[^\s#]/.exec(line)?.[1]
+    if (indent !== undefined) return indent
+  }
+  return '  '
+}
+
+/**
+ * Turn off the strict gate, unless the operator has already ruled on it.
+ *
+ * This is the half that survives the next dependency. pnpm 11 defaults
+ * `strictDepBuilds` to true, which turns any unapproved build script — in a
+ * package nobody here has heard of yet — into a failed install. False returns
+ * pnpm to warning and skipping, which is what an unattended bot needs.
+ * @param lines - the workspace document, split into lines.
+ * @returns the lines, with the setting appended when it was absent.
+ */
+function settleStrictDepBuilds(lines: readonly string[]): readonly string[] {
+  if (lines.some(line => topLevelKey(line) === 'strictDepBuilds')) return lines
+  return [...lines, '', 'strictDepBuilds: false']
+}
+
+/**
+ * Record the protobufjs decision: this build script is skipped on purpose.
+ *
+ * Its postinstall only prints a notice, so the choice is worth naming rather
+ * than leaving to the blanket gate — and an operator who keeps
+ * `strictDepBuilds` on needs the named decision to install at all, since only
+ * an undecided script trips that gate. Editing is best-effort: an `allowBuilds`
+ * block this cannot extend without guessing is left exactly as it is, never
+ * duplicated — a second `allowBuilds` key makes the document unparseable and
+ * takes the profile down harder than the problem being fixed.
+ * {@link settleStrictDepBuilds} keeps the install passing in that case.
+ * @param lines - the workspace document, split into lines.
+ * @returns the lines, with the decision recorded where that was safe.
+ */
+function settleProtobufjs(lines: readonly string[]): readonly string[] {
+  const start = lines.findIndex(line => topLevelKey(line) === 'allowBuilds')
+  if (start === -1) return [...lines, '', 'allowBuilds:', '  protobufjs: false']
+
+  const following = lines.slice(start + 1).findIndex(line => topLevelKey(line) !== undefined)
+  const end = following === -1 ? lines.length : start + 1 + following
+  const block = lines.slice(start + 1, end)
+  const entry = block.findIndex(line => ALLOW_BUILDS_ENTRY.test(line))
+  if (entry !== -1) return replacePlaceholder(lines, start + 1 + entry)
+
+  // Named in a spelling this does not edit — quoted, say. Adding an entry
+  // beside it would be the duplicate key all over again, one level down.
+  if (block.some(line => withoutComment(line).includes('protobufjs'))) return lines
+
+  // A block mapping takes an indented entry; an empty `{}` is emptied into one
+  // first, comment kept. Any other shape is left alone.
+  const declaration = lines[start] ?? ''
+  const value = withoutComment(TOP_LEVEL_KEY.exec(declaration)?.[2] ?? '')
+  if (value !== '' && value !== '{}') return lines
+  return [
+    ...lines.slice(0, start),
+    declaration.replace(/:\s*\{\s*\}/, ':'),
+    `${blockIndent(block)}protobufjs: false`,
+    ...lines.slice(start + 1),
+  ]
+}
+
+/**
+ * Settle the placeholder pnpm parks in a profile it could not finish.
+ * @param lines - the workspace document, split into lines.
+ * @param index - line holding the protobufjs entry.
+ * @returns the lines, with a placeholder resolved and any real choice kept.
+ */
+function replacePlaceholder(lines: readonly string[], index: number): readonly string[] {
+  const parts = ALLOW_BUILDS_ENTRY.exec(lines[index] ?? '')
+  const prefix = parts?.[1]
+  if (prefix === undefined || withoutComment(parts?.[2] ?? '') !== PNPM_BUILD_PLACEHOLDER) return lines
+  return lines.with(index, `${prefix}false`)
+}
+
+/**
+ * Settle the build-script policy of a workspace document that already exists.
+ *
+ * Lines are split on either ending and rejoined on `\n`: a CRLF document whose
+ * keys went unrecognized would have policy appended a second time, and a second
+ * `allowBuilds` key is the unparseable file this exists to avoid.
+ * @param document - contents of the profile's `pnpm-workspace.yaml`.
+ * @returns the document to write, identical when nothing needed settling.
+ */
+function settleBuildPolicy(document: string): string {
+  const lines = settleProtobufjs(settleStrictDepBuilds(document.trimEnd().split(/\r?\n/)))
+  return `${lines.join('\n')}\n`
+}
+
+/**
+ * Make unapproved dependency build scripts a decided matter before pnpm runs.
+ *
+ * DSH creates a profile and installs its first plugin in one command. Under
+ * pnpm 11 that first install stops at ERR_PNPM_IGNORED_BUILDS — today over
+ * protobufjs, tomorrow over whatever a transitive dependency brings with it —
+ * after parking a placeholder decision in the profile. So the policy is two
+ * halves: `strictDepBuilds: false` so an unapproved script is warned about and
+ * skipped rather than fatal, and an explicit protobufjs entry saying this one
+ * was considered. Both are written before the first install, and a profile a
+ * previous CLI left mid-failure is repaired the same way. An operator's own
+ * choice, on either half, is never overwritten.
  * @param profile - profile whose package-manager policy should be ready.
  * @param home - harness home; injectable for tests.
+ * @throws {Error} when the profile name would write outside the home.
  */
 export function ensureProfileBuildPolicy(profile: string, home: string = dshHome()): void {
+  const refusal = refuseProfileName(profile)
+  if (refusal !== undefined) throw new Error(refusal)
+
   const path = join(home, 'profiles', profile, 'pnpm-workspace.yaml')
-  if (!existsSync(path)) {
+  const document = existsSync(path) ? readFileSync(path, 'utf8') : undefined
+  if (document === undefined || document.trim() === '') {
     mkdirSync(dirname(path), { recursive: true })
     writeFileSync(path, PROFILE_PNPM_WORKSPACE)
     return
   }
 
-  const document = readFileSync(path, 'utf8')
-  const repaired = document.replace(
-    /^(\s*protobufjs:\s*)set this to true or false\s*$/m,
-    '$1false',
-  )
-  if (repaired !== document) writeFileSync(path, `${repaired.trimEnd()}\n`)
-  if (/^\s*protobufjs:\s*(?:true|false)\s*$/m.test(repaired)) return
-
-  const withPolicy = /^allowBuilds:\s*$/m.test(repaired)
-    ? repaired.replace(/^allowBuilds:\s*$/m, 'allowBuilds:\n  protobufjs: false')
-    : `${repaired.trimEnd()}\n\nallowBuilds:\n  protobufjs: false\n`
-  writeFileSync(path, `${withPolicy.trimEnd()}\n`)
+  const settled = settleBuildPolicy(document)
+  if (settled !== document) writeFileSync(path, settled)
 }
 
 /** Create the profile when absent, then install the matching plugin version into it. */

--- a/src/provision.ts
+++ b/src/provision.ts
@@ -49,6 +49,17 @@ export const ONBOARDING_WATCH_MS = 10 * 60 * 1000
 /** Log size past which `start` truncates it, since no supervisor rotates it. */
 export const LOG_TRUNCATE_BYTES = 10 * 1024 * 1024
 
+/** pnpm policy a standalone profile needs before its first dependency install. */
+const PROFILE_PNPM_WORKSPACE = `packages:
+  - .
+
+nodeLinker: hoisted
+autoInstallPeers: false
+
+allowBuilds:
+  protobufjs: false
+`
+
 /** What the operator asked for, after argument parsing. */
 export type Command =
   | { readonly kind: 'start'; readonly profile: string; readonly workspace: string }
@@ -484,6 +495,39 @@ function requireDsh(): string {
   return found
 }
 
+/**
+ * Make protobufjs's optional postinstall an explicit decision before pnpm runs.
+ *
+ * DSH creates a profile and installs its first plugin in one command. With
+ * pnpm 11, that first install writes a placeholder decision for protobufjs and
+ * then exits with ERR_PNPM_IGNORED_BUILDS. Pre-seeding the workspace avoids the
+ * failed first pass; repairing the exact placeholder also recovers profiles
+ * left behind by an older CLI. An operator's explicit true/false choice wins.
+ * @param profile - profile whose package-manager policy should be ready.
+ * @param home - harness home; injectable for tests.
+ */
+export function ensureProfileBuildPolicy(profile: string, home: string = dshHome()): void {
+  const path = join(home, 'profiles', profile, 'pnpm-workspace.yaml')
+  if (!existsSync(path)) {
+    mkdirSync(dirname(path), { recursive: true })
+    writeFileSync(path, PROFILE_PNPM_WORKSPACE)
+    return
+  }
+
+  const document = readFileSync(path, 'utf8')
+  const repaired = document.replace(
+    /^(\s*protobufjs:\s*)set this to true or false\s*$/m,
+    '$1false',
+  )
+  if (repaired !== document) writeFileSync(path, `${repaired.trimEnd()}\n`)
+  if (/^\s*protobufjs:\s*(?:true|false)\s*$/m.test(repaired)) return
+
+  const withPolicy = /^allowBuilds:\s*$/m.test(repaired)
+    ? repaired.replace(/^allowBuilds:\s*$/m, 'allowBuilds:\n  protobufjs: false')
+    : `${repaired.trimEnd()}\n\nallowBuilds:\n  protobufjs: false\n`
+  writeFileSync(path, `${withPolicy.trimEnd()}\n`)
+}
+
 /** Create the profile when absent, then install the matching plugin version into it. */
 function provision(dsh: string, profile: string, workspace: string): void {
   const installed = installedPluginVersion(profile)
@@ -494,6 +538,7 @@ function provision(dsh: string, profile: string, workspace: string): void {
     )
   }
   process.stderr.write(`dsh-lark-channel: provisioning profile ${profile}\n`)
+  ensureProfileBuildPolicy(profile)
   must([dsh, 'plugin', '--profile', profile, 'add', `dsh-lark-channel@${ownVersion()}`], workspace)
 }
 
@@ -804,6 +849,7 @@ function alignPluginVersion(profile: string): void {
       ? `dsh-lark-channel: installing the plugin ${version} into profile ${profile}\n`
       : `dsh-lark-channel: profile ${profile} has ${installed}; bringing it to ${version}\n`,
   )
+  ensureProfileBuildPolicy(profile)
   must([dsh, 'plugin', '--profile', profile, 'add', `dsh-lark-channel@${version}`])
 }
 

--- a/tests/provision.spec.ts
+++ b/tests/provision.spec.ts
@@ -132,42 +132,174 @@ describe('supervisorKind', () => {
 })
 
 describe('profile build policy', () => {
-  it('pre-seeds a fresh profile before its first pnpm install', () => {
+  /** Seed a profile directory with the workspace document a test starts from. */
+  const seedProfile = (document?: string): string => {
     const home = mkdtempSync(join(tmpdir(), 'dsh-home-'))
+    if (document !== undefined) {
+      mkdirSync(join(home, 'profiles', 'lark'), { recursive: true })
+      writeFileSync(join(home, 'profiles', 'lark', 'pnpm-workspace.yaml'), document)
+    }
+    return home
+  }
+
+  /** The profile's workspace document as it stands on disk. */
+  const readWorkspace = (home: string): string =>
+    readFileSync(join(home, 'profiles', 'lark', 'pnpm-workspace.yaml'), 'utf8')
+
+  /** The template DSH writes when it initializes a profile of its own. */
+  const DSH_TEMPLATE = 'packages:\n  - .\n\nnodeLinker: hoisted\nautoInstallPeers: false\n'
+
+  it('pre-seeds a fresh profile before its first pnpm install', () => {
+    const home = seedProfile()
+
     ensureProfileBuildPolicy('lark', home)
-    const document = readFileSync(join(home, 'profiles', 'lark', 'pnpm-workspace.yaml'), 'utf8')
+
+    const document = readWorkspace(home)
     expect(document).toContain('nodeLinker: hoisted')
+    expect(document).toContain('strictDepBuilds: false')
     expect(document).toContain('protobufjs: false')
   })
 
-  it('repairs the placeholder pnpm leaves after ERR_PNPM_IGNORED_BUILDS', () => {
-    const home = mkdtempSync(join(tmpdir(), 'dsh-home-'))
-    const directory = join(home, 'profiles', 'lark')
-    mkdirSync(directory, { recursive: true })
-    writeFileSync(join(directory, 'pnpm-workspace.yaml'), [
-      'packages:',
-      '  - .',
-      'allowBuilds:',
-      '  protobufjs: set this to true or false',
-      '',
-    ].join('\n'))
+  it('adds both halves to a profile built before this policy existed', () => {
+    const home = seedProfile(DSH_TEMPLATE)
 
     ensureProfileBuildPolicy('lark', home)
 
-    expect(readFileSync(join(directory, 'pnpm-workspace.yaml'), 'utf8'))
-      .toContain('protobufjs: false')
+    const document = readWorkspace(home)
+    expect(document).toContain(DSH_TEMPLATE.trimEnd())
+    expect(document).toContain('strictDepBuilds: false')
+    expect(document).toContain('allowBuilds:\n  protobufjs: false')
+  })
+
+  it('repairs the placeholder pnpm leaves after ERR_PNPM_IGNORED_BUILDS', () => {
+    const home = seedProfile('packages:\n  - .\nallowBuilds:\n  protobufjs: set this to true or false\n')
+
+    ensureProfileBuildPolicy('lark', home)
+
+    expect(readWorkspace(home)).toContain('  protobufjs: false')
   })
 
   it('preserves an operator choice to run protobufjs postinstall', () => {
-    const home = mkdtempSync(join(tmpdir(), 'dsh-home-'))
-    const directory = join(home, 'profiles', 'lark')
-    mkdirSync(directory, { recursive: true })
-    writeFileSync(join(directory, 'pnpm-workspace.yaml'), 'allowBuilds:\n  protobufjs: true\n')
+    const home = seedProfile('allowBuilds:\n  protobufjs: true\n')
 
     ensureProfileBuildPolicy('lark', home)
 
-    expect(readFileSync(join(directory, 'pnpm-workspace.yaml'), 'utf8'))
-      .toBe('allowBuilds:\n  protobufjs: true\n')
+    const document = readWorkspace(home)
+    expect(document).toContain('protobufjs: true')
+    expect(document).not.toContain('protobufjs: false')
+    expect(document).toContain('strictDepBuilds: false')
+  })
+
+  it('preserves an operator choice to keep the strict gate on', () => {
+    const home = seedProfile('strictDepBuilds: true\n')
+
+    ensureProfileBuildPolicy('lark', home)
+
+    const document = readWorkspace(home)
+    expect(document).toContain('strictDepBuilds: true')
+    expect(document).not.toContain('strictDepBuilds: false')
+    // The named decision is what carries a profile that keeps the gate on,
+    // since only an undecided build script trips it.
+    expect(document).toContain('  protobufjs: false')
+  })
+
+  it('never writes a second allowBuilds key, whatever shape the first one has', () => {
+    for (const existing of ['allowBuilds: {}\n', 'allowBuilds: # decided per package\n', 'allowBuilds: {esbuild: true}\n']) {
+      const home = seedProfile(`packages:\n  - .\n${existing}`)
+
+      ensureProfileBuildPolicy('lark', home)
+
+      const document = readWorkspace(home)
+      expect(document.match(/^allowBuilds\s*:/gm)).toHaveLength(1)
+      expect(document).toContain('strictDepBuilds: false')
+    }
+  })
+
+  it('leaves a protobufjs entry spelled a way it does not edit', () => {
+    const home = seedProfile('allowBuilds:\n  "protobufjs": false\n')
+
+    ensureProfileBuildPolicy('lark', home)
+
+    const document = readWorkspace(home)
+    expect(document.match(/protobufjs/g)).toHaveLength(1)
+    expect(document).toContain('strictDepBuilds: false')
+  })
+
+  it('keeps a comment on the allowBuilds line it opens up', () => {
+    const home = seedProfile('allowBuilds: {} # decided per package\n')
+
+    ensureProfileBuildPolicy('lark', home)
+
+    expect(readWorkspace(home)).toContain('allowBuilds: # decided per package\n  protobufjs: false')
+  })
+
+  it('leaves an allowBuilds block it cannot extend to the strict gate instead', () => {
+    const home = seedProfile('allowBuilds: {esbuild: true}\n')
+
+    ensureProfileBuildPolicy('lark', home)
+
+    const document = readWorkspace(home)
+    expect(document).toContain('allowBuilds: {esbuild: true}')
+    expect(document).not.toContain('protobufjs')
+  })
+
+  it('keeps other packages\' decisions when it records this one', () => {
+    const home = seedProfile('allowBuilds:\n  esbuild: true\n\nnodeLinker: hoisted\n')
+
+    ensureProfileBuildPolicy('lark', home)
+
+    const document = readWorkspace(home)
+    expect(document).toContain('  esbuild: true')
+    expect(document).toContain('  protobufjs: false')
+    expect(document).toContain('nodeLinker: hoisted')
+  })
+
+  it('indents its entry the way the block it joins is indented', () => {
+    const home = seedProfile('allowBuilds:\n    esbuild: true\n')
+
+    ensureProfileBuildPolicy('lark', home)
+
+    expect(readWorkspace(home)).toContain('allowBuilds:\n    protobufjs: false\n    esbuild: true')
+  })
+
+  it('reads a document written with CRLF endings', () => {
+    const home = seedProfile('packages:\r\n  - .\r\nallowBuilds:\r\n  protobufjs: set this to true or false\r\n')
+
+    ensureProfileBuildPolicy('lark', home)
+
+    const document = readWorkspace(home)
+    expect(document.match(/^allowBuilds\s*:/gm)).toHaveLength(1)
+    expect(document).toContain('  protobufjs: false')
+    expect(document).not.toContain('\r')
+  })
+
+  it('settles in one pass, so a second run rewrites nothing', () => {
+    const seeds = [
+      undefined,
+      DSH_TEMPLATE,
+      'allowBuilds:\n  protobufjs: set this to true or false\n',
+      'allowBuilds: {}\n',
+      'allowBuilds: {esbuild: true}\n',
+      'allowBuilds:\n    esbuild: true\n',
+      'strictDepBuilds: true\n',
+      'packages:\r\n  - .\r\n',
+    ]
+    for (const seed of seeds) {
+      const home = seedProfile(seed)
+      ensureProfileBuildPolicy('lark', home)
+      const settled = readWorkspace(home)
+
+      ensureProfileBuildPolicy('lark', home)
+
+      expect(readWorkspace(home)).toBe(settled)
+    }
+  })
+
+  it('refuses a profile name that would write outside the harness home', () => {
+    const home = mkdtempSync(join(tmpdir(), 'dsh-home-'))
+    for (const name of ['..', '../escape', 'nested/profile', '']) {
+      expect(() => ensureProfileBuildPolicy(name, home)).toThrow(/invalid profile name/)
+    }
   })
 })
 

--- a/tests/provision.spec.ts
+++ b/tests/provision.spec.ts
@@ -1,4 +1,4 @@
-import { chmodSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { delimiter, join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
@@ -8,6 +8,7 @@ import {
   SERVICE_LABEL,
   dshHome,
   envCredentials,
+  ensureProfileBuildPolicy,
   hasCredentialSection,
   isOnboarded,
   launchdPlist,
@@ -127,6 +128,46 @@ describe('supervisorKind', () => {
   it('names launchd on macOS and no supervisor on Windows', () => {
     expect(supervisorKind('darwin')).toBe('launchd')
     expect(supervisorKind('win32')).toBeUndefined()
+  })
+})
+
+describe('profile build policy', () => {
+  it('pre-seeds a fresh profile before its first pnpm install', () => {
+    const home = mkdtempSync(join(tmpdir(), 'dsh-home-'))
+    ensureProfileBuildPolicy('lark', home)
+    const document = readFileSync(join(home, 'profiles', 'lark', 'pnpm-workspace.yaml'), 'utf8')
+    expect(document).toContain('nodeLinker: hoisted')
+    expect(document).toContain('protobufjs: false')
+  })
+
+  it('repairs the placeholder pnpm leaves after ERR_PNPM_IGNORED_BUILDS', () => {
+    const home = mkdtempSync(join(tmpdir(), 'dsh-home-'))
+    const directory = join(home, 'profiles', 'lark')
+    mkdirSync(directory, { recursive: true })
+    writeFileSync(join(directory, 'pnpm-workspace.yaml'), [
+      'packages:',
+      '  - .',
+      'allowBuilds:',
+      '  protobufjs: set this to true or false',
+      '',
+    ].join('\n'))
+
+    ensureProfileBuildPolicy('lark', home)
+
+    expect(readFileSync(join(directory, 'pnpm-workspace.yaml'), 'utf8'))
+      .toContain('protobufjs: false')
+  })
+
+  it('preserves an operator choice to run protobufjs postinstall', () => {
+    const home = mkdtempSync(join(tmpdir(), 'dsh-home-'))
+    const directory = join(home, 'profiles', 'lark')
+    mkdirSync(directory, { recursive: true })
+    writeFileSync(join(directory, 'pnpm-workspace.yaml'), 'allowBuilds:\n  protobufjs: true\n')
+
+    ensureProfileBuildPolicy('lark', home)
+
+    expect(readFileSync(join(directory, 'pnpm-workspace.yaml'), 'utf8'))
+      .toBe('allowBuilds:\n  protobufjs: true\n')
   })
 })
 


### PR DESCRIPTION
## 背景

首次创建 DSH profile 时，pnpm 11 会要求明确处理 `protobufjs` 的 postinstall。如果 provisioning 没有预置策略，pnpm 会写入未决占位值并以 `ERR_PNPM_IGNORED_BUILDS` 退出，导致 `dsh-lark-channel start` 安装失败。

## 变更

- 在首次安装 profile 依赖前预置 pnpm `allowBuilds` 策略，明确跳过只输出兼容性提示的 `protobufjs` postinstall。
- 自动修复旧 profile 中 `set this to true or false` 的未决占位值。
- 保留用户已经显式设置的 `protobufjs: true` 或 `protobufjs: false`。
- 补充新 profile、旧占位配置和用户显式选择三类回归测试。
- 同步更新中英文 README、配置 JSDoc 和 `cordis.patch.yml` 说明。

## 影响

新用户执行 `dsh-lark-channel start` 时不再需要手工运行 `pnpm approve-builds`。已有明确构建策略的 profile 不会被覆盖。

## 验证

- `pnpm run typecheck`
- `pnpm test`（16 个测试文件，363 项测试通过）
- `pnpm run build`
- `pnpm run prepare`
- 手工验证 fresh profile provisioning 完成且 launchd 服务正常运行
